### PR TITLE
replace setup-miniconda by setup-micromamba for build

### DIFF
--- a/.github/workflows/opypackage-standard-v04.yml
+++ b/.github/workflows/opypackage-standard-v04.yml
@@ -1,0 +1,110 @@
+name: test-and-publish-package
+
+on:
+  workflow_call:
+    inputs:
+      # optional
+      install-eplus-920:
+        description: Should I install Energy Plus 9.2.0 ?
+        required: false
+        type: boolean
+
+      install-eplus-2210:
+        description: Should I install Energy Plus 22.1.0 ?
+        required: false
+        type: boolean
+
+      python-conda-requirement:
+        description: Specific python requirement to install with conda (for example "=3.7.0" or ">=3.7,<3.8") ?
+        required: false
+        type: string
+        default: ">=3.7,<3.8"
+
+      python-pip-requirement:
+        description: Specific python requirement to install with pip (for example "=3.7.0" or ">=3.7,<3.8") ?
+        required: false
+        type: string
+        default: ">=3.7"
+
+      publish-to-pypi:
+        description: Should I publish to Pypi ? (! only for public packages !)
+        required: false
+        type: boolean
+        default: false
+
+    secrets:
+      # mandatory
+      ADMIN_GITHUB_TOKEN:
+        description: Openergy admin github token
+        required: true
+      AZURE_CONDA_CHANNEL_KEY:
+        description: Azure Storage Account key
+        required: true
+
+      # optional
+      CONDA_CHANNEL_SYSADMIN_URL:
+        description: URL containing sysadmin password to use Openergy's private conda channel.
+        required: false
+      PYPI_OPENERGY_PASSWORD:
+        description: openergy's pypi account password (only if publish to pypi)
+        required: false
+
+jobs:
+  conda-build:
+    runs-on: ubuntu-latest
+    outputs:
+      build-version: ${{ steps.build-package.outputs.build-version }}
+    steps:
+      - name: build package
+        id: build-package
+        uses: openergy/ogithub-actions/actions/opypackage-conda-build-v04@master
+        with:
+          python-requirement: ${{ inputs.python-conda-requirement }}
+          admin-github-token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          conda-channel-sysadmin-url: ${{ secrets.CONDA_CHANNEL_SYSADMIN_URL }}
+
+  conda-test:
+    needs: [ conda-build ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: test package
+        uses: openergy/ogithub-actions/actions/opypackage-conda-test-v01@master
+        with:
+          admin-github-token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          python-requirement: ${{ inputs.python-conda-requirement }}
+          build-version: ${{ needs.conda-build.outputs.build-version }}
+          conda-channel-sysadmin-url: ${{ secrets.CONDA_CHANNEL_SYSADMIN_URL }}
+          install-eplus-920: ${{ inputs.install-eplus-920 }}
+          install-eplus-2210: ${{ inputs.install-eplus-2210 }}
+
+  version:
+    needs: [ conda-build, conda-test ]
+    runs-on: ubuntu-latest
+    if: needs.conda-build.outputs.build-version != 'next'
+    steps:
+      - name: version repo
+        uses: openergy/ogithub-actions/actions/opy-version-v01@master
+        with:
+          admin-github-token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          build-version: ${{ needs.conda-build.outputs.build-version }}
+
+  pypi-publish:
+    needs: [ conda-build, conda-test, version ]
+    runs-on: ubuntu-latest
+    if: ${{ inputs.publish-to-pypi }}
+    steps:
+      - name: publish package to pypi
+        uses: openergy/ogithub-actions/actions/opypackage-pip-build-and-publish-v01@master
+        with:
+          admin-github-token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          pypi-openergy-password: ${{ secrets.PYPI_OPENERGY_PASSWORD }}
+          python-requirement: ${{ inputs.python-pip-requirement }}
+
+  conda-publish:
+    needs: [ conda-build, conda-test, version ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: publish package to private conda registry
+        uses: openergy/ogithub-actions/actions/opypackage-conda-publish-v01@master
+        with:
+          azure-conda-channel-key: ${{ secrets.AZURE_CONDA_CHANNEL_KEY }}

--- a/actions/opypackage-conda-build-v02/this-action-is-deprecated.md
+++ b/actions/opypackage-conda-build-v02/this-action-is-deprecated.md
@@ -1,0 +1,2 @@
+# deprecated
+-> opypackage-conda-build-v03

--- a/actions/opypackage-conda-build-v03/this-action-is-deprecated.md
+++ b/actions/opypackage-conda-build-v03/this-action-is-deprecated.md
@@ -1,0 +1,2 @@
+# deprecated
+-> opypackage-conda-build-v04

--- a/actions/opypackage-conda-build-v04/action.yml
+++ b/actions/opypackage-conda-build-v04/action.yml
@@ -1,0 +1,123 @@
+name: Build Openergy python package
+description: build is uploaded to conda-build artifact
+inputs:
+  # mandatory
+  admin-github-token:
+    description: Openergy admin github token
+    required: true
+
+  # optional
+  conda-channel-sysadmin-url:
+    description: openergy conda channel (if openergy packages are needed for build)
+    required: false
+
+  python-requirement:
+    description: Specific python requirement to install (for example "=3.7.0" or ">=3.7,<3.8") ?
+    required: false
+    default: ">=3.7,<3.8"
+
+  package-dir-name:
+    description: name of the package in which is version.py
+    required: false
+    default: ${{ github.event.repository.name }}
+
+  # config
+  build-artifact-name:
+    description: name of the artifact in which build will be stored
+    required: false
+    default: conda-build
+
+outputs:
+  build-version:
+    description: version that is extracted from RELEASE.md
+    value: ${{ steps.set-version.outputs.build-version }}
+# https://github.com/marketplace/actions/setup-miniconda#use-a-default-shell
+# https://github.com/marketplace/actions/setup-miniconda#important
+runs:
+  using: composite
+  steps:
+    - name: checkout repo # automatically on push branch
+      uses: actions/checkout@v3
+      with:
+        path: repo  # Relative path under $GITHUB_WORKSPACE to place the repository
+        token: ${{ inputs.admin-github-token }}  # we want push to be done by Openergy Admin, for branch protection
+
+    - name: prepare conda cache  # https://github.com/marketplace/actions/setup-miniconda#caching
+      uses: actions/cache@v2
+      with:
+        path: ~/conda_pkgs_dir
+        key: ${{ runner.os }}-${{ hashFiles('${{ github.workspace }}/repo/requirements.txt') }}
+
+    - name: retrieve version in RELEASE.md ('next' or version number)
+      id: set-version
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}/repo
+      run: echo "::set-output name=build-version::$(sed -n '0,/^##/s/## //p' RELEASE.md)"
+
+    - name: if not next, set version in version.py (build will refuse next as version)
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}/repo
+      run: |
+        if [ '${{ steps.set-version.outputs.build-version}}' != 'next' ]; then
+          printf 'version = "${{ steps.set-version.outputs.build-version }}"\n' > ./${{ inputs.package-dir-name }}/version.py
+        fi
+
+#https://github.com/pandas-dev/pandas/blob/main/.github/workflows/package-checks.yml
+#https://medium.com/@QuantStack/open-software-packaging-for-science-61cecee7fc23:
+# setup-mamba was the original CI action with mamba, now is depreciated -> setup-micromamba is the maintained action
+    - name: install micromamba
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-name: build-env
+        condarc: |
+          channels:
+            - conda-forge
+        create-args: >-
+          boa
+        cache-downloads: true
+        cache-environment: true
+
+    - name: add openergy conda channel if input was provided
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}
+      run: |
+        set -e
+        [ -z ${{ inputs.conda-channel-sysadmin-url }} ] || conda config --system --add channels ${{ inputs.conda-channel-sysadmin-url }}
+
+    - name: prepare build info
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}/repo
+      run: |
+        set -e
+
+        # prepare directory
+        mkdir conda-build
+
+        # install boa to use mambabuild
+        mamba install boa -c conda-forge
+
+        # download create_meta script
+        wget https://raw.githubusercontent.com/openergy/ogithub-actions/master/actions/opypackage-build-v01/create_meta.py -P ${{ github.workspace }}
+
+        # create meta
+        python ${{ github.workspace }}/create_meta.py conda-build ${{ github.event.repository.name }} false "${{ inputs.python-requirement }}"
+
+    - name: build
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}/repo/conda-build
+      run: |
+        set -e
+
+        # log (for debug)
+        conda env list
+        conda config --show channels
+
+        # build
+        conda mambabuild . --croot ${{ github.workspace }}/conda-build-to-upload
+
+    - name: upload build
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ inputs.build-artifact-name }}
+        path: ${{ github.workspace }}/conda-build-to-upload
+        retention-days: 1

--- a/actions/opypackage-conda-build-v04/action.yml
+++ b/actions/opypackage-conda-build-v04/action.yml
@@ -93,9 +93,6 @@ runs:
         # prepare directory
         mkdir conda-build
 
-        # install boa to use mambabuild
-        mamba install boa -c conda-forge
-
         # download create_meta script
         wget https://raw.githubusercontent.com/openergy/ogithub-actions/master/actions/opypackage-build-v01/create_meta.py -P ${{ github.workspace }}
 

--- a/actions/opypackage-conda-build-v04/create_meta.py
+++ b/actions/opypackage-conda-build-v04/create_meta.py
@@ -1,0 +1,84 @@
+import os
+import sys
+
+meta = """
+package:
+  name: __name__
+  version: "__version__"
+
+source:
+  path: __path__
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+  include_recipe: False
+__noarch__
+
+requirements:
+  build:
+    - python__python_requirement__
+    - setuptools 
+    - pip
+__build_requirements__
+  
+  run:
+    - python__python_requirement__
+__dependencies__
+"""
+
+if __name__ == "__main__":
+    # --- retrieve parameters
+    target_dir_path = sys.argv[1]
+    repo_name = sys.argv[2]
+    arch_specific = sys.argv[3]
+    python_requirement = sys.argv[4]
+
+    # --- prepare variables
+    version = ""
+    path = os.getcwd()
+    try:
+        with open("./RELEASE.md", "r") as f:
+            for line in f.readlines():
+                if line.startswith("##"):
+                    version = line[2:].strip("#").strip()
+                    break
+    except:
+        raise ValueError("Could not parse version from RELEASE.md")
+    if version == "":
+        raise ValueError("Could not parse version from RELEASE.md")
+
+    # --- replace meta variables
+    if arch_specific == "true":
+        meta = meta.replace("__noarch__", "")
+        meta = meta.replace("__build_requirements__", "    - cython\n    - numpy")
+    else:
+        meta = meta.replace("__noarch__", "  noarch: python")
+        meta = meta.replace("__build_requirements__", "")
+    meta = meta.replace("__name__", repo_name)
+    meta = meta.replace("__version__", version)
+    meta = meta.replace("__path__", path)
+    meta = meta.replace("__python_requirement__", python_requirement)
+
+    # --- manage dependencies
+    dependencies = ""
+    # try:
+    with open("./requirements.txt", "r") as f:
+        for line in f.readlines():
+            line = line.strip()
+            if line.startswith("#") or line == "":
+                continue
+            dependencies += f"    - {line}\n"
+    # manage linux requirements
+    if arch_specific == "true" and os.path.isfile("./linux_requirements.txt"):
+        with open("./linux_requirements.txt", "r") as f:
+            for line in f.readlines():
+                line = line.strip()
+                if line.startswith("#") or line == "":
+                    continue
+                dependencies += f"    - {line}\n"
+    meta = meta.replace("__dependencies__", dependencies)
+
+    # write to target
+    with open(os.path.join(target_dir_path, "meta.yaml"), "w") as f:
+        f.write(meta)


### PR DESCRIPTION
setup-miniconda with boa install was getting troublesome and is replaced by setup-micromamba (github action to work with mamba), inspired by pandas 
https://github.com/pandas-dev/pandas/blob/main/.github/workflows/package-checks.yml
(setup-micromamba replaces setup-mamba): 
https://medium.com/@QuantStack/open-software-packaging-for-science-61cecee7fc23

@geoffroy-destaintot , if you validate the use of micromamba, should it be used for testing action? 