### PR TITLE
update github action to handle tests on different OS and python versions

### DIFF
--- a/.github/workflows/opypackage-standard-v05.yml
+++ b/.github/workflows/opypackage-standard-v05.yml
@@ -27,8 +27,9 @@ on:
         type: boolean
         default: false
 
-      make-doctest:
-        description: Should I run Sphinx documentation tests?
+      # documentation testing only, a doc build is triggered by readthedocs when pushed on master
+      check-documentation:
+        description: Should I check that documentation generates correctly?
         required: false
         type: boolean
         default: false
@@ -94,7 +95,7 @@ jobs:
           build-version: ${{ needs.conda-build.outputs.build-version }}
           conda-channel-sysadmin-url: ${{ secrets.CONDA_CHANNEL_SYSADMIN_URL }}
           install-eplus-2210: ${{ inputs.install-eplus-2210 }}
-          make-doctest: ${{ inputs.make-doctest}}
+          check-documentation: ${{ inputs.check-documentation}}
 
   version:
     needs: [ conda-build, conda-test ]

--- a/.github/workflows/opypackage-standard-v05.yml
+++ b/.github/workflows/opypackage-standard-v05.yml
@@ -13,13 +13,13 @@ on:
         description: Specific python requirement to install with conda (for example "=3.7.0" or ">=3.7,<3.8") ?
         required: false
         type: string
-        default: ">=3.8,<3.13"
+        default: ">=3.8"
 
       python-pip-requirement:
         description: Specific python requirement to install with pip (for example "=3.7.0" or ">=3.7,<3.8") ?
         required: false
         type: string
-        default: ">=3.8,<3.13"
+        default: ">=3.8"
 
       publish-to-pypi:
         description: Should I publish to Pypi ? (! only for public packages !)
@@ -40,7 +40,7 @@ on:
         type: string
         default: "['ubuntu-latest']"
 
-      python-versions:
+      python-test-versions:
         description: Python versions to be tested
         required: false
         type: string
@@ -83,7 +83,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJson(inputs.os-requirements) }}
-        python-version: ${{ fromJson(inputs.python-versions) }}
+        python-version: ${{ fromJson(inputs.python-test-versions) }}
     steps:
       - name: test package
         uses: openergy/ogithub-actions/actions/opypackage-conda-test-v02@master

--- a/.github/workflows/opypackage-standard-v05.yml
+++ b/.github/workflows/opypackage-standard-v05.yml
@@ -1,0 +1,122 @@
+name: test-and-publish-package
+
+on:
+  workflow_call:
+    inputs:
+      # optional
+      install-eplus-2210:
+        description: Should I install Energy Plus 22.1.0 ?
+        required: false
+        type: boolean
+
+      python-conda-requirement:
+        description: Specific python requirement to install with conda (for example "=3.7.0" or ">=3.7,<3.8") ?
+        required: false
+        type: string
+        default: ">=3.8,<3.13"
+
+      python-pip-requirement:
+        description: Specific python requirement to install with pip (for example "=3.7.0" or ">=3.7,<3.8") ?
+        required: false
+        type: string
+        default: ">=3.8,<3.13"
+
+      publish-to-pypi:
+        description: Should I publish to Pypi ? (! only for public packages !)
+        required: false
+        type: boolean
+        default: false
+
+      # tests can be executed on different os (ubuntu, linux, macos), different python versions
+      os-requirements:
+        description: OS requirements
+        required: false
+        type: string
+        default: "['ubuntu-latest']"
+
+      python-versions:
+        description: Python versions to be tested
+        required: false
+        type: string
+        default: "['3.12']"
+
+    secrets:
+      # mandatory
+      ADMIN_GITHUB_TOKEN:
+        description: Openergy admin github token
+        required: true
+      AZURE_CONDA_CHANNEL_KEY:
+        description: Azure Storage Account key
+        required: true
+
+      # optional
+      CONDA_CHANNEL_SYSADMIN_URL:
+        description: URL containing sysadmin password to use Openergy's private conda channel.
+        required: false
+      PYPI_OPENERGY_PASSWORD:
+        description: openergy's pypi account password (only if publish to pypi)
+        required: false
+
+jobs:
+  conda-build:
+    runs-on: ubuntu-latest
+    outputs:
+      build-version: ${{ steps.build-package.outputs.build-version }}
+    steps:
+      - name: build package
+        id: build-package
+        uses: openergy/ogithub-actions/actions/opypackage-conda-build-v05@master
+        with:
+          python-requirement: ${{ inputs.python-conda-requirement }}
+          admin-github-token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          conda-channel-sysadmin-url: ${{ secrets.CONDA_CHANNEL_SYSADMIN_URL }}
+
+  conda-test:
+    needs: [ conda-build ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ${{ fromJson(inputs.os-requirements) }}
+        python-version: ${{ fromJson(inputs.python-versions) }}
+    steps:
+      - name: test package
+        uses: openergy/ogithub-actions/actions/opypackage-conda-test-v02@master
+        with:
+          admin-github-token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          python-requirement: ${{ inputs.python-conda-requirement }}
+          python-version: ${{  matrix.python-version }}
+          build-version: ${{ needs.conda-build.outputs.build-version }}
+          conda-channel-sysadmin-url: ${{ secrets.CONDA_CHANNEL_SYSADMIN_URL }}
+          install-eplus-2210: ${{ inputs.install-eplus-2210 }}
+
+  version:
+    needs: [ conda-build, conda-test ]
+    runs-on: ubuntu-latest
+    if: needs.conda-build.outputs.build-version != 'next'
+    steps:
+      - name: version repo
+        uses: openergy/ogithub-actions/actions/opy-version-v01@master
+        with:
+          admin-github-token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          build-version: ${{ needs.conda-build.outputs.build-version }}
+
+  pypi-publish:
+    needs: [ conda-build, conda-test, version ]
+    runs-on: ubuntu-latest
+    if: ${{ inputs.publish-to-pypi }}
+    steps:
+      - name: publish package to pypi
+        uses: openergy/ogithub-actions/actions/opypackage-pip-build-and-publish-v01@master
+        with:
+          admin-github-token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          pypi-openergy-password: ${{ secrets.PYPI_OPENERGY_PASSWORD }}
+          python-requirement: ${{ inputs.python-pip-requirement }}
+
+  conda-publish:
+    needs: [ conda-build, conda-test, version ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: publish package to private conda registry
+        uses: openergy/ogithub-actions/actions/opypackage-conda-publish-v01@master
+        with:
+          azure-conda-channel-key: ${{ secrets.AZURE_CONDA_CHANNEL_KEY }}

--- a/.github/workflows/opypackage-standard-v05.yml
+++ b/.github/workflows/opypackage-standard-v05.yml
@@ -27,6 +27,12 @@ on:
         type: boolean
         default: false
 
+      make-doctest:
+        description: Should I run Sphinx documentation tests?
+        required: false
+        type: boolean
+        default: false
+
       # tests can be executed on different os (ubuntu, linux, macos), different python versions
       os-requirements:
         description: OS requirements
@@ -88,6 +94,7 @@ jobs:
           build-version: ${{ needs.conda-build.outputs.build-version }}
           conda-channel-sysadmin-url: ${{ secrets.CONDA_CHANNEL_SYSADMIN_URL }}
           install-eplus-2210: ${{ inputs.install-eplus-2210 }}
+          make-doctest: ${{ inputs.make-doctest}}
 
   version:
     needs: [ conda-build, conda-test ]

--- a/actions/opypackage-conda-build-v05/action.yml
+++ b/actions/opypackage-conda-build-v05/action.yml
@@ -95,7 +95,7 @@ runs:
         # prepare directory
         mkdir conda-build
         # download create_meta script
-        wget https://raw.githubusercontent.com/openergy/ogithub-actions/cc_opyplus/actions/opypackage-conda-build-v05/create_meta.py -P ${{ github.workspace }}
+        wget https://raw.githubusercontent.com/openergy/ogithub-actions/master/actions/opypackage-conda-build-v05/create_meta.py -P ${{ github.workspace }}
 
         # create meta
         python ${{ github.workspace }}/create_meta.py conda-build ${{ github.event.repository.name }} false "${{ inputs.python-requirement }}"

--- a/actions/opypackage-conda-build-v05/action.yml
+++ b/actions/opypackage-conda-build-v05/action.yml
@@ -1,0 +1,120 @@
+name: Build Openergy python package
+description: build is uploaded to conda-build artifact
+inputs:
+  # mandatory
+  admin-github-token:
+    description: Openergy admin github token
+    required: true
+
+  # optional
+  conda-channel-sysadmin-url:
+    description: openergy conda channel (if openergy packages are needed for build)
+    required: false
+
+  python-requirement:
+    description: Specific python requirement to install (for example "=3.7.0" or ">=3.7,<3.8") ?
+    required: false
+    default: ">=3.8,<3.13"
+
+  package-dir-name:
+    description: name of the package in which is version.py
+    required: false
+    default: ${{ github.event.repository.name }}
+
+  # config
+  build-artifact-name:
+    description: name of the artifact in which build will be stored
+    required: false
+    default: conda-build
+
+outputs:
+  build-version:
+    description: version that is extracted from RELEASE.md
+    value: ${{ steps.set-version.outputs.build-version }}
+
+runs:
+  using: composite
+  steps:
+    - name: checkout repo # automatically on push branch
+      uses: actions/checkout@v4
+      with:
+        path: repo  # Relative path under $GITHUB_WORKSPACE to place the repository
+        token: ${{ inputs.admin-github-token }}  # we want push to be done by Openergy Admin, for branch protection
+
+    - name: prepare conda cache  # https://github.com/marketplace/actions/setup-miniconda#caching
+      uses: actions/cache@v4
+      with:
+        path: ~/conda_pkgs_dir
+        key: ${{ runner.os }}-${{ hashFiles('${{ github.workspace }}/repo/requirements.txt') }}
+
+    - name: retrieve version in RELEASE.md ('next' or version number)
+      id: set-version
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}/repo
+      run: echo "::set-output name=build-version::$(sed -n '0,/^##/s/## //p' RELEASE.md)"
+
+    - name: if not next, set version in version.py (build will refuse next as version)
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}/repo
+      run: |
+        if [ '${{ steps.set-version.outputs.build-version}}' != 'next' ]; then
+          printf 'version = "${{ steps.set-version.outputs.build-version }}"\n' > ./${{ inputs.package-dir-name }}/version.py
+        fi
+
+#https://github.com/pandas-dev/pandas/blob/main/.github/workflows/package-checks.yml
+#https://medium.com/@QuantStack/open-software-packaging-for-science-61cecee7fc23:
+# setup-mamba was the original CI action with mamba, now is depreciated -> setup-micromamba is the maintained action
+    - name: install micromamba
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-name: build-env
+        condarc: |
+          channels:
+            - conda-forge
+        create-args: >-
+          boa
+        init-shell: >-
+          bash
+          powershell
+        cache-downloads: true
+        cache-environment: true
+
+    - name: add openergy conda channel if input was provided
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}
+      run: |
+        set -e
+        [ -z ${{ inputs.conda-channel-sysadmin-url }} ] || conda config --system --add channels ${{ inputs.conda-channel-sysadmin-url }}
+
+    - name: Prepare build info
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}/repo
+      run: |
+        set -e
+
+        # prepare directory
+        mkdir conda-build
+        # download create_meta script
+        wget https://raw.githubusercontent.com/openergy/ogithub-actions/cc_opyplus/actions/opypackage-conda-build-v05/create_meta.py -P ${{ github.workspace }}
+
+        # create meta
+        python ${{ github.workspace }}/create_meta.py conda-build ${{ github.event.repository.name }} false "${{ inputs.python-requirement }}"
+
+    - name: Build
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}/repo/conda-build
+      run: |
+        set -e
+        # log (for debug)
+        conda env list
+        conda config --show channels
+
+        # build
+        conda mambabuild . --croot ${{ github.workspace }}/conda-build-to-upload
+
+
+    - name: Upload build
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.build-artifact-name }}
+        path: ${{ github.workspace }}/conda-build-to-upload

--- a/actions/opypackage-conda-build-v05/create_meta.py
+++ b/actions/opypackage-conda-build-v05/create_meta.py
@@ -1,0 +1,84 @@
+import os
+import sys
+
+meta = """
+package:
+  name: __name__
+  version: "__version__"
+
+source:
+  path: __path__
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+  include_recipe: False
+__noarch__
+
+requirements:
+  build:
+    - python__python_requirement__
+    - setuptools 
+    - pip
+__build_requirements__
+  
+  run:
+    - python__python_requirement__
+__dependencies__
+"""
+
+if __name__ == "__main__":
+    # --- retrieve parameters
+    target_dir_path = sys.argv[1]
+    repo_name = sys.argv[2]
+    arch_specific = sys.argv[3]
+    python_requirement = sys.argv[4]
+
+    # --- prepare variables
+    version = ""
+    path = os.getcwd()
+    try:
+        with open("./RELEASE.md", "r") as f:
+            for line in f.readlines():
+                if line.startswith("##"):
+                    version = line[2:].strip("#").strip()
+                    break
+    except:
+        raise ValueError("Could not parse version from RELEASE.md")
+    if version == "":
+        raise ValueError("Could not parse version from RELEASE.md")
+
+    # --- replace meta variables
+    if arch_specific == "true":
+        meta = meta.replace("__noarch__", "")
+        meta = meta.replace("__build_requirements__", "    - cython\n    - numpy")
+    else:
+        meta = meta.replace("__noarch__", "  noarch: python")
+        meta = meta.replace("__build_requirements__", "")
+    meta = meta.replace("__name__", repo_name)
+    meta = meta.replace("__version__", version)
+    meta = meta.replace("__path__", path)
+    meta = meta.replace("__python_requirement__", python_requirement)
+
+    # --- manage dependencies
+    dependencies = ""
+    # try:
+    with open("./requirements.txt", "r") as f:
+        for line in f.readlines():
+            line = line.strip()
+            if line.startswith("#") or line == "":
+                continue
+            dependencies += f"    - {line}\n"
+    # manage linux requirements
+    if arch_specific == "true" and os.path.isfile("./linux_requirements.txt"):
+        with open("./linux_requirements.txt", "r") as f:
+            for line in f.readlines():
+                line = line.strip()
+                if line.startswith("#") or line == "":
+                    continue
+                dependencies += f"    - {line}\n"
+    meta = meta.replace("__dependencies__", dependencies)
+
+    # write to target
+    with open(os.path.join(target_dir_path, "meta.yaml"), "w") as f:
+        f.write(meta)

--- a/actions/opypackage-conda-test-v02/action.yml
+++ b/actions/opypackage-conda-test-v02/action.yml
@@ -1,0 +1,178 @@
+name: Test Openergy python package
+description: conda-build artifact is used as package to test
+inputs:
+  # mandatory
+  admin-github-token:
+    description: Openergy admin github token
+    required: true
+  build-version:
+    description: version that was extracted from RELEASE.md
+    required: true
+
+  # optional
+  conda-channel-sysadmin-url:
+    description: openergy conda channel (if openergy packages are needed for build)
+    required: false
+  python-requirement:
+    description: Specific python requirement to install (for example "=3.7.0" or ">=3.7,<3.8") ?
+    required: false
+    default: ">=3.8,<3.13"
+  python-version:
+    description: Python version
+    required: false
+    default: "3.12"
+  install-eplus-920:
+    description: Should I install Energy Plus 9.2.0 ?
+    required: false
+  install-eplus-2210:
+    description: Should I install Energy Plus 22.1.0 ?
+    required: false
+
+  # config
+  build-artifact-name:
+    description: name of the artifact in which package build is stored
+    required: false
+    default: conda-build
+
+# https://github.com/marketplace/actions/setup-miniconda#use-a-default-shell
+# https://github.com/marketplace/actions/setup-miniconda#important
+runs:
+  using: composite
+  steps:
+    - name: checkout repo  # (automatically on push branch)
+      uses: actions/checkout@v2
+      with:
+        path: repo  # Relative path under $GITHUB_WORKSPACE to place the repository
+        token: ${{ inputs.admin-github-token }}  # we want push to be done by Openergy Admin, for branch protection
+
+    - name: download build
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.build-artifact-name }}
+        path: ${{ github.workspace }}/conda-build
+
+    - name: prepare miniconda cache
+      uses: actions/cache@v2
+      with:
+        path: ~/conda_pkgs_dir
+        key: ${{ runner.os }}-${{ hashFiles('${{ github.workspace }}/conda-build/**') }}
+
+    - name: install miniconda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        # bug appeared in 01/2023, seems to be caused by no miniconda-version and mamba-version: "*". Fixed by
+        # putting miniconda-version: "latest", thanks to following comment :
+        # https://github.com/conda-incubator/setup-miniconda/issues/182#issuecomment-1032055889
+        miniconda-version: "latest"
+        mamba-version: "*"
+        channels: conda-forge
+        auto-activate-base: true
+        activate-environment: true
+
+    - name: add openergy conda channel if input was provided
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}
+      run: |
+        set -e
+        [ -z ${{ inputs.conda-channel-sysadmin-url }} ] || conda config --system --add channels ${{ inputs.conda-channel-sysadmin-url }}
+
+    - name: install EnergyPlus 22.1.0 if required (Ubuntu)
+      if: ${{ runner.os != 'Windows' && inputs.install-eplus-2210 == 'true' }}
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}
+      run: |
+        set -e
+        wget -q https://github.com/NREL/EnergyPlus/releases/download/v22.1.0/EnergyPlus-22.1.0-ed759b17ee-Linux-Ubuntu18.04-x86_64.sh
+        echo "y\r" | sudo bash ./EnergyPlus-22.1.0-ed759b17ee-Linux-Ubuntu18.04-x86_64.sh
+        sudo rm ./EnergyPlus-22.1.0-ed759b17ee-Linux-Ubuntu18.04-x86_64.sh
+
+    - name: install EnergyPlus 22.1.0 if required (Windows)
+      if: ${{ runner.os == 'Windows' && inputs.install-eplus-2210 == 'true' }}
+      shell: pwsh
+      working-directory: ${{ github.workspace }}
+      run: |
+        $url = "https://github.com/NREL/EnergyPlus/releases/download/v22.1.0/EnergyPlus-22.1.0-ed759b17ee-Windows-x86_64.exe"
+        $output = "$env:TEMP\eplus.exe"
+        Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -Uri $url -OutFile $output
+        Write-Host "Executing EnergyPlus installer"
+        & $output /S | Out-Null
+
+#
+    - name: create environment
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}
+      run: |
+        set -e
+        echo "pytest" >> env-requirements.txt
+        echo "pytest-cov" >> env-requirements.txt
+
+        # output requirements for debug
+        cat env-requirements.txt
+
+        # create environment
+        mamba create -n openergy -q python=${{ inputs.python-version }} --file env-requirements.txt
+
+    # install and test package (Ubuntu)
+    - name: install package
+      if: runner.os != 'Windows'
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}
+      run: |
+        set -e
+        # activate environment
+        conda activate openergy
+
+        # log (for debug)
+        conda env list
+        conda config --show channels
+
+        # install
+        mamba install -q -c ${{ github.workspace }}/conda-build ${{ github.event.repository.name }}=${{ inputs.build-version }}
+
+    - name: copy and run tests
+      if: runner.os != 'Windows'
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}
+      run: |
+        set -e
+        # activate
+        conda activate openergy
+        conda list
+
+        # copy tests
+        cp -r ${{ github.workspace }}/repo/tests ${{ github.workspace }}
+
+        # run tests
+        pytest --cov=. tests/
+
+    # install and test package (Windows)
+    - name: install package (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      working-directory: ${{ github.workspace }}
+      run: |
+        # activate environment
+        conda activate openergy
+
+        # log (for debug)
+        conda env list
+        conda config --show channels
+
+        # install
+        mamba install -q -c ${{ github.workspace }}\conda-build ${{ github.event.repository.name }}=${{ inputs.build-version }}
+
+    - name: copy and run tests (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      working-directory: ${{ github.workspace }}
+      run: |
+        # activate
+        conda activate openergy
+
+        # copy tests
+        Copy-Item -Recurse -Path ${{ github.workspace }}/repo/tests -Destination ${{ github.workspace }}
+
+        # run tests
+        pytest --cov=. tests/

--- a/actions/opypackage-conda-test-v02/action.yml
+++ b/actions/opypackage-conda-test-v02/action.yml
@@ -27,6 +27,9 @@ inputs:
   install-eplus-2210:
     description: Should I install Energy Plus 22.1.0 ?
     required: false
+  make-doctest:
+    description: Should I run Sphinx doctest ?
+    required: false
 
   # config
   build-artifact-name:
@@ -99,7 +102,7 @@ runs:
         Write-Host "Executing EnergyPlus installer"
         & $output /S | Out-Null
 
-#
+    #
     - name: create environment
       shell: bash -l {0}
       working-directory: ${{ github.workspace }}
@@ -176,3 +179,19 @@ runs:
 
         # run tests
         pytest --cov=. tests/
+
+
+    - name: build and test doc
+      if: ${{ inputs.make-doctest == 'true' }}
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: |
+        set -e
+        conda activate openergy
+        pip install -r ${{ github.workspace }}/repo/docs/requirements.txt
+        cd ${{ github.workspace }}/repo/docs
+        make html
+        make doctest
+        
+
+

--- a/actions/opypackage-conda-test-v02/action.yml
+++ b/actions/opypackage-conda-test-v02/action.yml
@@ -120,7 +120,7 @@ runs:
         mamba create -n openergy -q python=${{ inputs.python-version }} --file env-requirements.txt
 
     # install and test package (Ubuntu)
-    - name: install package
+    - name: install package (Ubuntu)
       if: runner.os != 'Windows'
       shell: bash -l {0}
       working-directory: ${{ github.workspace }}
@@ -136,7 +136,7 @@ runs:
         # install
         mamba install -q -c ${{ github.workspace }}/conda-build ${{ github.event.repository.name }}=${{ inputs.build-version }}
 
-    - name: copy and run tests
+    - name: copy and run tests (Ubuntu)
       if: runner.os != 'Windows'
       shell: bash -l {0}
       working-directory: ${{ github.workspace }}

--- a/actions/opypackage-conda-test-v02/action.yml
+++ b/actions/opypackage-conda-test-v02/action.yml
@@ -16,7 +16,7 @@ inputs:
   python-requirement:
     description: Specific python requirement to install (for example "=3.7.0" or ">=3.7,<3.8") ?
     required: false
-    default: ">=3.8,<3.13"
+    default: ">=3.8"
   python-version:
     description: Python version
     required: false
@@ -89,6 +89,8 @@ runs:
         echo "y\r" | sudo bash ./EnergyPlus-22.1.0-ed759b17ee-Linux-Ubuntu18.04-x86_64.sh
         sudo rm ./EnergyPlus-22.1.0-ed759b17ee-Linux-Ubuntu18.04-x86_64.sh
 
+    # fixme: powershell install of energyplus not working with latest versions
+    # this step was used for opyplus automatic testing under windows, but was dropped because of this issue
     - name: install EnergyPlus 22.1.0 if required (Windows)
       if: ${{ runner.os == 'Windows' && inputs.install-eplus-2210 == 'true' }}
       shell: pwsh
@@ -181,17 +183,18 @@ runs:
         pytest --cov=. tests/
 
 
-    - name: build and test doc
+    - name: testing doc examples and testing build  html
       if: ${{ inputs.make-doctest == 'true' }}
       shell: bash
       working-directory: ${{ github.workspace }}
       run: |
+        # testing only, a doc build is triggered by readthedocs if versioned (see admin settings)
         set -e
         conda activate openergy
         pip install -r ${{ github.workspace }}/repo/docs/requirements.txt
         cd ${{ github.workspace }}/repo/docs
-        make html
         make doctest
+        make html
         
 
 

--- a/actions/opypackage-conda-test-v02/action.yml
+++ b/actions/opypackage-conda-test-v02/action.yml
@@ -27,7 +27,7 @@ inputs:
   install-eplus-2210:
     description: Should I install Energy Plus 22.1.0 ?
     required: false
-  make-doctest:
+  check-documentation:
     description: Should I run Sphinx doctest ?
     required: false
 
@@ -184,11 +184,11 @@ runs:
 
 
     - name: testing doc examples and testing build  html
-      if: ${{ inputs.make-doctest == 'true' }}
+      if: ${{ inputs.check-documentation == 'true' }}
       shell: bash
       working-directory: ${{ github.workspace }}
       run: |
-        # testing only, a doc build is triggered by readthedocs if versioned (see admin settings)
+        # testing only, a doc build is triggered by readthedocs when pushed on master
         set -e
         conda activate openergy
         pip install -r ${{ github.workspace }}/repo/docs/requirements.txt


### PR DESCRIPTION
- default python requirements is now >=3.8
- tests on different os and different python versions is now possible
- testing doc is implemented: doc build is triggered by the merge on the branch (specified in the readthedocs admin settings)