### PR TITLE
chore: update actions/upload-artifact

### DIFF
--- a/actions/opypackage-build-v01/action.yml
+++ b/actions/opypackage-build-v01/action.yml
@@ -97,7 +97,7 @@ runs:
         conda-build . --croot ${{ github.workspace }}/conda-build-to-upload
 
     - name: upload build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.build-artifact-name }}
         path: ${{ github.workspace }}/conda-build-to-upload

--- a/actions/opypackage-conda-build-v01/action.yml
+++ b/actions/opypackage-conda-build-v01/action.yml
@@ -97,7 +97,7 @@ runs:
         conda-build . --croot ${{ github.workspace }}/conda-build-to-upload
 
     - name: upload build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.build-artifact-name }}
         path: ${{ github.workspace }}/conda-build-to-upload

--- a/actions/opypackage-conda-build-v02/action.yml
+++ b/actions/opypackage-conda-build-v02/action.yml
@@ -96,7 +96,7 @@ runs:
         conda mambabuild . --croot ${{ github.workspace }}/conda-build-to-upload
 
     - name: upload build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.build-artifact-name }}
         path: ${{ github.workspace }}/conda-build-to-upload

--- a/actions/opypackage-conda-build-v03/action.yml
+++ b/actions/opypackage-conda-build-v03/action.yml
@@ -110,7 +110,7 @@ runs:
         conda mambabuild . --croot ${{ github.workspace }}/conda-build-to-upload
 
     - name: upload build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.build-artifact-name }}
         path: ${{ github.workspace }}/conda-build-to-upload

--- a/actions/opypackage-conda-build-v04/action.yml
+++ b/actions/opypackage-conda-build-v04/action.yml
@@ -113,7 +113,7 @@ runs:
         conda mambabuild . --croot ${{ github.workspace }}/conda-build-to-upload
 
     - name: upload build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.build-artifact-name }}
         path: ${{ github.workspace }}/conda-build-to-upload


### PR DESCRIPTION
update actions/upload-artifact@v2 to actions/upload-artifact@v4

actions/upload-artifact@v2 got deprecated and refuses to run anymore