### PR TITLE
chore: update actions/download-artifact

### DIFF
--- a/actions/opypackage-conda-publish-v01/action.yml
+++ b/actions/opypackage-conda-publish-v01/action.yml
@@ -62,7 +62,7 @@ runs:
       run: rclone copy condachannel:static conda-build
 
     - name: "download build"
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: conda-build
         path: ${{ github.workspace }}/conda-build

--- a/actions/opypackage-conda-publish-v01/using-mount.yml
+++ b/actions/opypackage-conda-publish-v01/using-mount.yml
@@ -67,7 +67,7 @@ runs:
         activate-environment: ""
 
     - name: "add new version build"
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: conda-build
         path: ${{ github.workspace }}/conda-build

--- a/actions/opypackage-conda-test-v01/action.yml
+++ b/actions/opypackage-conda-test-v01/action.yml
@@ -42,7 +42,7 @@ runs:
         token: ${{ inputs.admin-github-token }}  # we want push to be done by Openergy Admin, for branch protection
 
     - name: download build
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.build-artifact-name }}
         path: ${{ github.workspace }}/conda-build

--- a/actions/opypackage-test-v01/action.yml
+++ b/actions/opypackage-test-v01/action.yml
@@ -45,7 +45,7 @@ runs:
         token: ${{ inputs.admin-github-token }}  # we want push to be done by Openergy Admin, for branch protection
 
     - name: download build
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.build-artifact-name }}
         path: ${{ github.workspace }}/conda-build


### PR DESCRIPTION
update actions/download-artifact@v2 to actions/download-artifact@v4

actions/download-artifact@v2 got deprecated and refuses to run anymore