### PR TITLE
fix: replace mamba by conda

### DIFF
--- a/actions/opypackage-conda-test-v01/action.yml
+++ b/actions/opypackage-conda-test-v01/action.yml
@@ -108,7 +108,7 @@ runs:
         cat env-requirements.txt
 
         # create environment
-        mamba create -n openergy -q --file env-requirements.txt
+        conda create -n openergy -q --file env-requirements.txt
         conda list 
 
     - name: install package
@@ -124,7 +124,7 @@ runs:
         conda config --show channels
 
         # install
-        mamba install -q -c ${{ github.workspace }}/conda-build ${{ github.event.repository.name }}=${{ inputs.build-version }}
+        conda install -q -c ${{ github.workspace }}/conda-build ${{ github.event.repository.name }}=${{ inputs.build-version }}
 
     - name: copy and run tests
       shell: bash -l {0}

--- a/actions/opypackage-conda-test-v02/action.yml
+++ b/actions/opypackage-conda-test-v02/action.yml
@@ -117,7 +117,7 @@ runs:
         cat env-requirements.txt
 
         # create environment
-        mamba create -n openergy -q python=${{ inputs.python-version }} --file env-requirements.txt
+        conda create -n openergy -q python=${{ inputs.python-version }} --file env-requirements.txt
 
     # install and test package (Ubuntu)
     - name: install package (Ubuntu)
@@ -134,7 +134,7 @@ runs:
         conda config --show channels
 
         # install
-        mamba install -q -c ${{ github.workspace }}/conda-build ${{ github.event.repository.name }}=${{ inputs.build-version }}
+        conda install -q -c ${{ github.workspace }}/conda-build ${{ github.event.repository.name }}=${{ inputs.build-version }}
 
     - name: copy and run tests (Ubuntu)
       if: runner.os != 'Windows'
@@ -166,7 +166,7 @@ runs:
         conda config --show channels
 
         # install
-        mamba install -q -c ${{ github.workspace }}\conda-build ${{ github.event.repository.name }}=${{ inputs.build-version }}
+        conda install -q -c ${{ github.workspace }}\conda-build ${{ github.event.repository.name }}=${{ inputs.build-version }}
 
     - name: copy and run tests (Windows)
       if: runner.os == 'Windows'

--- a/actions/opypackage-test-v01/action.yml
+++ b/actions/opypackage-test-v01/action.yml
@@ -97,7 +97,7 @@ runs:
         cat env-requirements.txt
 
         # create environment
-        mamba create -n openergy -q --file env-requirements.txt
+        conda create -n openergy -q --file env-requirements.txt
 
     - name: install package
       shell: bash -l {0}
@@ -112,7 +112,7 @@ runs:
         conda config --show channels
 
         # install
-        mamba install -q -c ${{ github.workspace }}/conda-build ${{ github.event.repository.name }}=${{ inputs.build-version }}
+        conda install -q -c ${{ github.workspace }}/conda-build ${{ github.event.repository.name }}=${{ inputs.build-version }}
 
     - name: copy and run tests
       shell: bash -l {0}


### PR DESCRIPTION
mamba was getting 404s

conda uses the mamba engine now, so no point in keeping mamba