### PR TITLE
Standard v06: mamba to conda

### DIFF
--- a/.github/workflows/opypackage-standard-v06.yml
+++ b/.github/workflows/opypackage-standard-v06.yml
@@ -1,0 +1,131 @@
+name: test-and-publish-package
+
+on:
+  workflow_call:
+    inputs:
+      # optional
+      install-eplus-2210:
+        description: Should I install Energy Plus 22.1.0 ?
+        required: false
+        type: boolean
+
+      python-conda-requirement:
+        description: Specific python requirement to install with conda (for example "=3.7.0" or ">=3.7,<3.8") ?
+        required: false
+        type: string
+        default: ">=3.8"
+
+      python-pip-requirement:
+        description: Specific python requirement to install with pip (for example "=3.7.0" or ">=3.7,<3.8") ?
+        required: false
+        type: string
+        default: ">=3.8"
+
+      publish-to-pypi:
+        description: Should I publish to Pypi ? (! only for public packages !)
+        required: false
+        type: boolean
+        default: false
+
+      # documentation testing only, a doc build is triggered by readthedocs when pushed on master
+      check-documentation:
+        description: Should I check that documentation generates correctly?
+        required: false
+        type: boolean
+        default: false
+
+      # tests can be executed on different os (ubuntu, linux, macos), different python versions
+      os-requirements:
+        description: OS requirements
+        required: false
+        type: string
+        default: "['ubuntu-latest']"
+
+      python-test-versions:
+        description: Python versions to be tested
+        required: false
+        type: string
+        default: "['3.12']"
+
+    secrets:
+      # mandatory
+      ADMIN_GITHUB_TOKEN:
+        description: Openergy admin github token
+        required: true
+      AZURE_CONDA_CHANNEL_KEY:
+        description: Azure Storage Account key
+        required: true
+
+      # optional
+      CONDA_CHANNEL_SYSADMIN_URL:
+        description: URL containing sysadmin password to use Openergy's private conda channel.
+        required: false
+      PYPI_API_TOKEN:
+        description: openergy's pypi api token (only if publish to pypi)
+        required: false
+
+jobs:
+  conda-build:
+    runs-on: ubuntu-latest
+    outputs:
+      build-version: ${{ steps.build-package.outputs.build-version }}
+    steps:
+      - name: build package
+        id: build-package
+        uses: openergy/ogithub-actions/actions/opypackage-conda-build-v05@master
+        with:
+          python-requirement: ${{ inputs.python-conda-requirement }}
+          admin-github-token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          conda-channel-sysadmin-url: ${{ secrets.CONDA_CHANNEL_SYSADMIN_URL }}
+
+  conda-test:
+    needs: [conda-build]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ${{ fromJson(inputs.os-requirements) }}
+        python-version: ${{ fromJson(inputs.python-test-versions) }}
+    steps:
+      - name: test package
+        uses: openergy/ogithub-actions/actions/opypackage-conda-test-v03@master
+        with:
+          admin-github-token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          python-requirement: ${{ inputs.python-conda-requirement }}
+          python-version: ${{  matrix.python-version }}
+          build-version: ${{ needs.conda-build.outputs.build-version }}
+          conda-channel-sysadmin-url: ${{ secrets.CONDA_CHANNEL_SYSADMIN_URL }}
+          install-eplus-2210: ${{ inputs.install-eplus-2210 }}
+          check-documentation: ${{ inputs.check-documentation}}
+
+  version:
+    needs: [conda-build, conda-test]
+    runs-on: ubuntu-latest
+    if: needs.conda-build.outputs.build-version != 'next'
+    steps:
+      - name: version repo
+        uses: openergy/ogithub-actions/actions/opy-version-v01@master
+        with:
+          admin-github-token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          build-version: ${{ needs.conda-build.outputs.build-version }}
+
+  pypi-publish:
+    needs: [conda-build, conda-test, version]
+    runs-on: ubuntu-latest
+    if: ${{ inputs.publish-to-pypi }}
+    steps:
+      - name: publish package to pypi
+        uses: openergy/ogithub-actions/actions/opypackage-pip-build-and-publish-v02@master
+        with:
+          admin-github-token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          pypi-openergy-token: ${{ secrets.PYPI_API_TOKEN }}
+          python-requirement: ${{ inputs.python-pip-requirement }}
+          build-version: ${{ needs.conda-build.outputs.build-version }}
+
+  conda-publish:
+    needs: [conda-build, conda-test, version]
+    runs-on: ubuntu-latest
+    steps:
+      - name: publish package to private conda registry
+        uses: openergy/ogithub-actions/actions/opypackage-conda-publish-v02@master
+        with:
+          azure-conda-channel-key: ${{ secrets.AZURE_CONDA_CHANNEL_KEY }}

--- a/actions/opypackage-conda-build-v01/action.yml
+++ b/actions/opypackage-conda-build-v01/action.yml
@@ -5,26 +5,26 @@ inputs:
   admin-github-token:
     description: Openergy admin github token
     required: true
-    deprecationMessage: opypackage-build-v01 is deprecated, use opypackage-conda-build-v01 instead
+    deprecationMessage: opypackage-conda-build-v01 is deprecated, use opypackage-conda-build-v02 instead
 
   # optional
   conda-channel-sysadmin-url:
     description: openergy conda channel (if openergy packages are needed for build)
     required: false
-    deprecationMessage: opypackage-build-v01 is deprecated, use opypackage-conda-build-v01 instead
+    deprecationMessage: opypackage-conda-build-v01 is deprecated, use opypackage-conda-build-v02 instead
 
   python-requirement:
     description: Specific python requirement to install (for example "=3.7.0" or ">=3.7,<3.8") ?
     required: false
     default: ">=3.7,<3.8"
-    deprecationMessage: opypackage-build-v01 is deprecated, use opypackage-conda-build-v01 instead
+    deprecationMessage: opypackage-conda-build-v01 is deprecated, use opypackage-conda-build-v02 instead
 
   # config
   build-artifact-name:
     description: name of the artifact in which build will be stored
     required: false
     default: conda-build
-    deprecationMessage: opypackage-build-v01 is deprecated, use opypackage-conda-build-v01 instead
+    deprecationMessage: opypackage-conda-build-v01 is deprecated, use opypackage-conda-build-v02 instead
 
 outputs:
   build-version:

--- a/actions/opypackage-conda-build-v02/action.yml
+++ b/actions/opypackage-conda-build-v02/action.yml
@@ -5,22 +5,26 @@ inputs:
   admin-github-token:
     description: Openergy admin github token
     required: true
+    deprecationMessage: oopypackage-conda-build-v02 is deprecated, use opypackage-conda-build-v03 instead
 
   # optional
   conda-channel-sysadmin-url:
     description: openergy conda channel (if openergy packages are needed for build)
     required: false
+    deprecationMessage: oopypackage-conda-build-v02 is deprecated, use opypackage-conda-build-v03 instead
 
   python-requirement:
     description: Specific python requirement to install (for example "=3.7.0" or ">=3.7,<3.8") ?
     required: false
     default: ">=3.7,<3.8"
+    deprecationMessage: oopypackage-conda-build-v02 is deprecated, use opypackage-conda-build-v03 instead
 
   # config
   build-artifact-name:
     description: name of the artifact in which build will be stored
     required: false
     default: conda-build
+    deprecationMessage: oopypackage-conda-build-v02 is deprecated, use opypackage-conda-build-v03 instead
 
 outputs:
   build-version:

--- a/actions/opypackage-conda-build-v03/action.yml
+++ b/actions/opypackage-conda-build-v03/action.yml
@@ -5,27 +5,32 @@ inputs:
   admin-github-token:
     description: Openergy admin github token
     required: true
+    deprecationMessage: opypackage-conda-build-v03 is deprecated, use opypackage-conda-build-v04 instead
 
   # optional
   conda-channel-sysadmin-url:
     description: openergy conda channel (if openergy packages are needed for build)
     required: false
+    deprecationMessage: opypackage-conda-build-v03 is deprecated, use opypackage-conda-build-v04 instead
 
   python-requirement:
     description: Specific python requirement to install (for example "=3.7.0" or ">=3.7,<3.8") ?
     required: false
     default: ">=3.7,<3.8"
+    deprecationMessage: opypackage-conda-build-v03 is deprecated, use opypackage-conda-build-v04 instead
 
   package-dir-name:
     description: name of the package in which is version.py
     required: false
     default: ${{ github.event.repository.name }}
+    deprecationMessage: opypackage-conda-build-v03 is deprecated, use opypackage-conda-build-v04 instead
 
   # config
   build-artifact-name:
     description: name of the artifact in which build will be stored
     required: false
     default: conda-build
+    deprecationMessage: opypackage-conda-build-v03 is deprecated, use opypackage-conda-build-v04 instead
 
 outputs:
   build-version:

--- a/actions/opypackage-conda-build-v04/action.yml
+++ b/actions/opypackage-conda-build-v04/action.yml
@@ -5,27 +5,32 @@ inputs:
   admin-github-token:
     description: Openergy admin github token
     required: true
+    deprecationMessage: opypackage-build-v04 is deprecated, use opypackage-conda-build-v05 instead
 
   # optional
   conda-channel-sysadmin-url:
     description: openergy conda channel (if openergy packages are needed for build)
     required: false
+    deprecationMessage: opypackage-build-v04 is deprecated, use opypackage-conda-build-v05 instead
 
   python-requirement:
     description: Specific python requirement to install (for example "=3.7.0" or ">=3.7,<3.8") ?
     required: false
     default: ">=3.7,<3.8"
+    deprecationMessage: opypackage-build-v04 is deprecated, use opypackage-conda-build-v05 instead
 
   package-dir-name:
     description: name of the package in which is version.py
     required: false
     default: ${{ github.event.repository.name }}
+    deprecationMessage: opypackage-build-v04 is deprecated, use opypackage-conda-build-v05 instead
 
   # config
   build-artifact-name:
     description: name of the artifact in which build will be stored
     required: false
     default: conda-build
+    deprecationMessage: opypackage-build-v04 is deprecated, use opypackage-conda-build-v05 instead
 
 outputs:
   build-version:

--- a/actions/opypackage-conda-build-v04/this-action-is-deprecated.md
+++ b/actions/opypackage-conda-build-v04/this-action-is-deprecated.md
@@ -1,0 +1,2 @@
+# deprecated
+-> opypackage-conda-build-v05

--- a/actions/opypackage-conda-publish-v01/action.yml
+++ b/actions/opypackage-conda-publish-v01/action.yml
@@ -5,12 +5,14 @@ inputs:
   azure-conda-channel-key:
     description: Azure conda channel key
     required: true
+    deprecationMessage: opypackage-conda-publish-v01 is deprecated, use opypackage-conda-build-v02 instead
 
   # config
   build-artifact-name:
     description: name of the artifact in which build will be stored
     required: false
     default: conda-build
+    deprecationMessage: opypackage-conda-publish-v01 is deprecated, use opypackage-conda-build-v02 instead
 
 # https://github.com/marketplace/actions/setup-miniconda#use-a-default-shell
 # https://github.com/marketplace/actions/setup-miniconda#important

--- a/actions/opypackage-conda-publish-v01/this-action-is-deprecated.md
+++ b/actions/opypackage-conda-publish-v01/this-action-is-deprecated.md
@@ -1,0 +1,2 @@
+# deprecated
+-> opypackage-conda-publish-v02

--- a/actions/opypackage-conda-test-v01/action.yml
+++ b/actions/opypackage-conda-test-v01/action.yml
@@ -5,30 +5,37 @@ inputs:
   admin-github-token:
     description: Openergy admin github token
     required: true
+    deprecationMessage: opypackage-conda-test-v01 is deprecated, use opypackage-conda-test-v02 instead
   build-version:
     description: version that was extracted from RELEASE.md
     required: true
+    deprecationMessage: opypackage-conda-test-v01 is deprecated, use opypackage-conda-test-v02 instead
 
   # optional
   conda-channel-sysadmin-url:
     description: openergy conda channel (if openergy packages are needed for build)
     required: false
+    deprecationMessage: opypackage-conda-test-v01 is deprecated, use opypackage-conda-test-v02 instead
   python-requirement:
     description: Specific python requirement to install (for example "=3.7.0" or ">=3.7,<3.8") ?
     required: false
     default: ">=3.7,<3.8"
+    deprecationMessage: opypackage-conda-test-v01 is deprecated, use opypackage-conda-test-v02 instead
   install-eplus-920:
     description: Should I install Energy Plus 9.2.0 ?
     required: false
+    deprecationMessage: opypackage-conda-test-v01 is deprecated, use opypackage-conda-test-v02 instead
   install-eplus-2210:
     description: Should I install Energy Plus 22.1.0 ?
     required: false
+    deprecationMessage: opypackage-conda-test-v01 is deprecated, use opypackage-conda-test-v02 instead
 
   # config
   build-artifact-name:
     description: name of the artifact in which package build is stored
     required: false
     default: conda-build
+    deprecationMessage: opypackage-conda-test-v01 is deprecated, use opypackage-conda-test-v02 instead
 
 # https://github.com/marketplace/actions/setup-miniconda#use-a-default-shell
 # https://github.com/marketplace/actions/setup-miniconda#important

--- a/actions/opypackage-conda-test-v01/this-action-is-deprecated.md
+++ b/actions/opypackage-conda-test-v01/this-action-is-deprecated.md
@@ -1,0 +1,2 @@
+# deprecated
+-> opypackage-conda-test-v02

--- a/actions/opypackage-conda-test-v02/action.yml
+++ b/actions/opypackage-conda-test-v02/action.yml
@@ -5,37 +5,46 @@ inputs:
   admin-github-token:
     description: Openergy admin github token
     required: true
+    deprecationMessage: opypackage-conda-test-v02 is deprecated, use opypackage-conda-test-v03 instead
   build-version:
     description: version that was extracted from RELEASE.md
     required: true
+    deprecationMessage: opypackage-conda-test-v02 is deprecated, use opypackage-conda-test-v03 instead
 
   # optional
   conda-channel-sysadmin-url:
     description: openergy conda channel (if openergy packages are needed for build)
     required: false
+    deprecationMessage: opypackage-conda-test-v02 is deprecated, use opypackage-conda-test-v03 instead
   python-requirement:
     description: Specific python requirement to install (for example "=3.7.0" or ">=3.7,<3.8") ?
     required: false
     default: ">=3.8"
+    deprecationMessage: opypackage-conda-test-v02 is deprecated, use opypackage-conda-test-v03 instead
   python-version:
     description: Python version
     required: false
     default: "3.12"
+    deprecationMessage: opypackage-conda-test-v02 is deprecated, use opypackage-conda-test-v03 instead
   install-eplus-920:
     description: Should I install Energy Plus 9.2.0 ?
     required: false
+    deprecationMessage: opypackage-conda-test-v02 is deprecated, use opypackage-conda-test-v03 instead
   install-eplus-2210:
     description: Should I install Energy Plus 22.1.0 ?
     required: false
+    deprecationMessage: opypackage-conda-test-v02 is deprecated, use opypackage-conda-test-v03 instead
   check-documentation:
     description: Should I run Sphinx doctest ?
     required: false
+    deprecationMessage: opypackage-conda-test-v02 is deprecated, use opypackage-conda-test-v03 instead
 
   # config
   build-artifact-name:
     description: name of the artifact in which package build is stored
     required: false
     default: conda-build
+    deprecationMessage: opypackage-conda-test-v02 is deprecated, use opypackage-conda-test-v03 instead
 
 # https://github.com/marketplace/actions/setup-miniconda#use-a-default-shell
 # https://github.com/marketplace/actions/setup-miniconda#important

--- a/actions/opypackage-conda-test-v02/this-action-is-deprecated.md
+++ b/actions/opypackage-conda-test-v02/this-action-is-deprecated.md
@@ -1,0 +1,2 @@
+# deprecated
+-> opypackage-conda-test-v03

--- a/actions/opypackage-conda-test-v03/action.yml
+++ b/actions/opypackage-conda-test-v03/action.yml
@@ -1,0 +1,196 @@
+name: Test Openergy python package
+description: conda-build artifact is used as package to test
+inputs:
+  # mandatory
+  admin-github-token:
+    description: Openergy admin github token
+    required: true
+  build-version:
+    description: version that was extracted from RELEASE.md
+    required: true
+
+  # optional
+  conda-channel-sysadmin-url:
+    description: openergy conda channel (if openergy packages are needed for build)
+    required: false
+  python-requirement:
+    description: Specific python requirement to install (for example "=3.7.0" or ">=3.7,<3.8") ?
+    required: false
+    default: ">=3.8"
+  python-version:
+    description: Python version
+    required: false
+    default: "3.12"
+  install-eplus-920:
+    description: Should I install Energy Plus 9.2.0 ?
+    required: false
+  install-eplus-2210:
+    description: Should I install Energy Plus 22.1.0 ?
+    required: false
+  check-documentation:
+    description: Should I run Sphinx doctest ?
+    required: false
+
+  # config
+  build-artifact-name:
+    description: name of the artifact in which package build is stored
+    required: false
+    default: conda-build
+
+# https://github.com/marketplace/actions/setup-miniconda#use-a-default-shell
+# https://github.com/marketplace/actions/setup-miniconda#important
+runs:
+  using: composite
+  steps:
+    - name: checkout repo # (automatically on push branch)
+      uses: actions/checkout@v2
+      with:
+        path: repo # Relative path under $GITHUB_WORKSPACE to place the repository
+        token: ${{ inputs.admin-github-token }} # we want push to be done by Openergy Admin, for branch protection
+
+    - name: download build
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.build-artifact-name }}
+        path: ${{ github.workspace }}/conda-build
+
+    - name: prepare miniconda cache
+      uses: actions/cache@v4
+      with:
+        path: ~/conda_pkgs_dir
+        key: ${{ runner.os }}-${{ hashFiles('${{ github.workspace }}/conda-build/**') }}
+
+    - name: install miniconda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        # bug appeared in 01/2023, seems to be caused by no miniconda-version and mamba-version: "*". Fixed by
+        # putting miniconda-version: "latest", thanks to following comment :
+        # https://github.com/conda-incubator/setup-miniconda/issues/182#issuecomment-1032055889
+        miniconda-version: "latest"
+        mamba-version: "*"
+        channels: conda-forge
+        auto-activate-base: true
+        activate-environment: true
+
+    - name: add openergy conda channel if input was provided
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}
+      run: |
+        set -e
+        [ -z ${{ inputs.conda-channel-sysadmin-url }} ] || conda config --system --add channels ${{ inputs.conda-channel-sysadmin-url }}
+
+    - name: install EnergyPlus 22.1.0 if required (Ubuntu)
+      if: ${{ runner.os != 'Windows' && inputs.install-eplus-2210 == 'true' }}
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}
+      run: |
+        set -e
+        wget -q https://github.com/NREL/EnergyPlus/releases/download/v22.1.0/EnergyPlus-22.1.0-ed759b17ee-Linux-Ubuntu18.04-x86_64.sh
+        echo "y\r" | sudo bash ./EnergyPlus-22.1.0-ed759b17ee-Linux-Ubuntu18.04-x86_64.sh
+        sudo rm ./EnergyPlus-22.1.0-ed759b17ee-Linux-Ubuntu18.04-x86_64.sh
+
+    # fixme: powershell install of energyplus not working with latest versions
+    # this step was used for opyplus automatic testing under windows, but was dropped because of this issue
+    - name: install EnergyPlus 22.1.0 if required (Windows)
+      if: ${{ runner.os == 'Windows' && inputs.install-eplus-2210 == 'true' }}
+      shell: pwsh
+      working-directory: ${{ github.workspace }}
+      run: |
+        $url = "https://github.com/NREL/EnergyPlus/releases/download/v22.1.0/EnergyPlus-22.1.0-ed759b17ee-Windows-x86_64.exe"
+        $output = "$env:TEMP\eplus.exe"
+        Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -Uri $url -OutFile $output
+        Write-Host "Executing EnergyPlus installer"
+        & $output /S | Out-Null
+
+    #
+    - name: create environment
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}
+      run: |
+        set -e
+        echo "pytest" >> env-requirements.txt
+        echo "pytest-cov" >> env-requirements.txt
+
+        # output requirements for debug
+        cat env-requirements.txt
+
+        # create environment
+        conda create -n openergy -q python=${{ inputs.python-version }} --file env-requirements.txt
+
+    # install and test package (Ubuntu)
+    - name: install package (Ubuntu)
+      if: runner.os != 'Windows'
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}
+      run: |
+        set -e
+        # activate environment
+        conda activate openergy
+
+        # log (for debug)
+        conda env list
+        conda config --show channels
+
+        # install
+        conda install -q -c ${{ github.workspace }}/conda-build ${{ github.event.repository.name }}=${{ inputs.build-version }}
+
+    - name: copy and run tests (Ubuntu)
+      if: runner.os != 'Windows'
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}
+      run: |
+        set -e
+        # activate
+        conda activate openergy
+        conda list
+
+        # copy tests
+        cp -r ${{ github.workspace }}/repo/tests ${{ github.workspace }}
+
+        # run tests
+        pytest --cov=. tests/
+
+    # install and test package (Windows)
+    - name: install package (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      working-directory: ${{ github.workspace }}
+      run: |
+        # activate environment
+        conda activate openergy
+
+        # log (for debug)
+        conda env list
+        conda config --show channels
+
+        # install
+        conda install -q -c ${{ github.workspace }}\conda-build ${{ github.event.repository.name }}=${{ inputs.build-version }}
+
+    - name: copy and run tests (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      working-directory: ${{ github.workspace }}
+      run: |
+        # activate
+        conda activate openergy
+
+        # copy tests
+        Copy-Item -Recurse -Path ${{ github.workspace }}/repo/tests -Destination ${{ github.workspace }}
+
+        # run tests
+        pytest --cov=. tests/
+
+    - name: testing doc examples and testing build  html
+      if: ${{ inputs.check-documentation == 'true' }}
+      shell: bash -l {0}
+      working-directory: ${{ github.workspace }}
+      run: |
+        # testing only, a doc build is triggered by readthedocs when pushed on master
+        set -e
+        conda activate openergy
+        pip install -r ${{ github.workspace }}/repo/docs/requirements.txt
+        cd ${{ github.workspace }}/repo/docs
+        make doctest
+        make html


### PR DESCRIPTION
Move from mamba to conda since mamba stopped working.

Added deprecation warnings on old actions.